### PR TITLE
Fix configuration with .screepsrc

### DIFF
--- a/lib/shared.js
+++ b/lib/shared.js
@@ -43,7 +43,7 @@ try {
   opts = ini.parse(fs.readFileSync('./.screepsrc', {encoding: 'utf8'}))
 } catch (e) {}
 opts.history = opts.history || {}
-Object.assign(opts.history, DEFAULTS, opts.history, ENV)
+opts.history = Object.assign({}, DEFAULTS, opts.history, ENV)
 
 class FileAdapter {
   constructor (opts) {


### PR DESCRIPTION
I tried without success to configure this module using the `.screepsrc` method. I believe I am using Node v10, but I am not sure as I am running screeps server on windows through steam.

Digging through code, it appears that this line doesn't work as I would have expected:

```javascript
Object.assign(opts.history, DEFAULTS, opts.history, ENV)
```

I would expect the above to pick values from `ENV`, then `opts.history`, then `DEFAULT`. And thus, with an empty `ENV` and values in `opts.history`, it should override the default.

However, that's not what happens. Consider this example:

```javascript
> a = {x: 1, y: 2}
{ x: 1, y: 2 }
> b = {x: 10, y: 20}
{ x: 10, y: 20 }
> Object.assign(a, b, a)
{ x: 10, y: 20 }
> a
{ x: 10, y: 20 }
```

I believe what happens internally in `Object.assign(a, b, a)` is something along those lines:
* Set `a.x` (first param) to `b.x` (second param), which set `a.x` to `10`
* Set `a.x` (first param) to `a.x` (second param) as the last param takes priority, but now `a.x = 10` and thus we're just overriding `a.x` with the same value, `a.x`.
* Same with `a.y` and `b.y`

It does not happen with the following code, because the object being set is brand new:

```javascript
> a = Object.assign({}, a, b, a)
{ x: 1, y: 2 }
> a
{ x: 1, y: 2 }
```

I made the update in my local node_modules and the config in `./.screepsrc` is honored. 

If you're able to reproduce the problem on your end here is a fix for you! I think this might still be good to ship because that's the way MDN recommend to do merging:

> **Merging objects with same properties**
>
>```javascript
> const o1 = { a: 1, b: 1, c: 1 };
> const o2 = { b: 2, c: 2 };
> const o3 = { c: 3 };
> 
> const obj = Object.assign({}, o1, o2, o3);
> console.log(obj); // { a: 1, b: 2, c: 3 }
> ```
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#Merging_objects_with_same_properties