### PR TITLE
Add HISTORY_ENDPOINT

### DIFF
--- a/lib/shared.js
+++ b/lib/shared.js
@@ -20,7 +20,8 @@ let ENV = {
   accessKeyId: process.env.HISTORY_ACCESS_KEY_ID || process.env.AWS_ACCESS_KEY_ID,
   secretAccessKey: process.env.HISTORY_SECRET_ACCESS_KEY || process.env.AWS_SECRET_ACCESS_KEY,
   bucket: process.env.HISTORY_BUCKET,
-  path: process.env.HISTORY_PATH
+  path: process.env.HISTORY_PATH,
+  endpoint: process.env.HISTORY_ENDPOINT
 }
 
 let keys = Object.keys(ENV)


### PR DESCRIPTION
Add `HISTORY_ENDPOINT` to make it easier to configure other S3 endpoints (i.e. Minio) in a kubernetes deployment.