### PR TITLE
Properly await for cleanup

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -19,7 +19,8 @@ module.exports = function engine (config) {
       config.engine.driver.history.upload = async (roomId, baseTime) => {
         // Do nothing other than cleanup, hooking roomDone to trigger actual saving
         if (baseTime % 1000 === 0) {
-          config.history.shared.cleanup(roomId, baseTime - KEEP_TICKS)
+          console.log(`cleaning up history before ${baseTime - KEEP_TICKS}`)
+          await config.history.shared.cleanup(roomId, baseTime - KEEP_TICKS)
         }
       }
     }


### PR DESCRIPTION
This fixes the following error appearing in the logs:
```
screeps-1  | 2025-02-18T14:42:33.145068754Z [engine_processor9] (node:122) UnhandledPromiseRejectionWarning: Error
screeps-1  | 2025-02-18T14:42:33.145075166Z     at Database.conn.serialize (/screeps/mods/node_modules/sequelize/lib/dialects/sqlite/query.js:185:27)
screeps-1  | 2025-02-18T14:42:33.145083949Z     at Promise (/screeps/mods/node_modules/sequelize/lib/dialects/sqlite/query.js:183:50)
screeps-1  | 2025-02-18T14:42:33.145085275Z     at new Promise (<anonymous>)
screeps-1  | 2025-02-18T14:42:33.145086656Z     at Query.run (/screeps/mods/node_modules/sequelize/lib/dialects/sqlite/query.js:183:12)
screeps-1  | 2025-02-18T14:42:33.145087767Z     at retry (/screeps/mods/node_modules/sequelize/lib/sequelize.js:315:28)
```